### PR TITLE
Implement Firebase auth context

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-native-firebase/auth": "^18.6.0",
     "@react-native-firebase/firestore": "^18.6.0",
     "@react-native-firebase/messaging": "^18.6.0",
-    "react-native-google-mobile-ads": "^10.6.0"
+    "react-native-google-mobile-ads": "^10.6.0",
+    "@react-native-google-signin/google-signin": "^9.0.0"
   }
 }

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,12 +1,55 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
+import auth from '@react-native-firebase/auth';
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
 
 export const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
 
+  useEffect(() => {
+    GoogleSignin.configure();
+    const unsubscribe = auth().onAuthStateChanged(setUser);
+    return unsubscribe;
+  }, []);
+
+  const signUp = async (email, password) => {
+    try {
+      await auth().createUserWithEmailAndPassword(email, password);
+    } catch (error) {
+      console.error('Error during sign up:', error);
+    }
+  };
+
+  const signIn = async (email, password) => {
+    try {
+      await auth().signInWithEmailAndPassword(email, password);
+    } catch (error) {
+      console.error('Error during sign in:', error);
+    }
+  };
+
+  const signOut = async () => {
+    try {
+      await auth().signOut();
+    } catch (error) {
+      console.error('Error during sign out:', error);
+    }
+  };
+
+  const signInWithGoogle = async () => {
+    try {
+      await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
+      const { idToken } = await GoogleSignin.signIn();
+      const credential = auth.GoogleAuthProvider.credential(idToken);
+      await auth().signInWithCredential(credential);
+    } catch (error) {
+      console.error('Error during Google sign in:', error);
+    }
+  };
+
   return (
-    <AuthContext.Provider value={{ user, setUser }}>
+    <AuthContext.Provider value={{ user, signUp, signIn, signOut, signInWithGoogle }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- implement `AuthContext` with sign-in/out methods and Google login
- add missing Google Sign-In dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685975637fd083209742743ddd74807e