### PR TITLE
Add stack-based navigation with auth handling

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,5 @@
 // see README for folder structure
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './src/contexts/AuthContext';
 import { PlanProvider } from './src/contexts/PlanContext';
 import { QuizProvider } from './src/contexts/QuizContext';
@@ -10,9 +9,7 @@ const App = () => (
   <AuthProvider>
     <PlanProvider>
       <QuizProvider>
-        <NavigationContainer>
-          <AppNavigator />
-        </NavigationContainer>
+        <AppNavigator />
       </QuizProvider>
     </PlanProvider>
   </AuthProvider>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "react": "18.2.0",
     "react-native": "0.72.5",
     "react-navigation": "^4.4.4",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/stack": "^6.3.16",
     "@react-native-firebase/app": "^18.6.0",
     "@react-native-firebase/auth": "^18.6.0",
     "@react-native-firebase/firestore": "^18.6.0",

--- a/src/navigation/AppNavigator.js
+++ b/src/navigation/AppNavigator.js
@@ -1,24 +1,54 @@
-import { createAppContainer } from 'react-navigation';
-import { createStackNavigator } from 'react-navigation-stack';
+import React, { useContext } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { AuthContext } from '../contexts/AuthContext';
 import LoginScreen from '../screens/LoginScreen';
 import HomeScreen from '../screens/HomeScreen';
 import QuizScreen from '../screens/QuizScreen';
-import ResultScreen from '../screens/ResultScreen';
 import MockExamScreen from '../screens/MockExamScreen';
+import ResultScreen from '../screens/ResultScreen';
 import AdviceScreen from '../screens/AdviceScreen';
 
-const Stack = createStackNavigator(
-  {
-    Login: LoginScreen,
-    Home: HomeScreen,
-    Quiz: QuizScreen,
-    Result: ResultScreen,
-    MockExam: MockExamScreen,
-    Advice: AdviceScreen,
+const Stack = createStackNavigator();
+
+const linking = {
+  prefixes: ['reviewersph://'],
+  config: {
+    screens: {
+      Login: 'login',
+      Home: 'home',
+      Quiz: 'quiz',
+      MockExam: 'mock-exam',
+      Result: 'result',
+      Advice: 'advice',
+    },
   },
-  {
-    initialRouteName: 'Login',
-  }
+};
+
+const AuthStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen name="Login" component={LoginScreen} />
+  </Stack.Navigator>
 );
 
-export default createAppContainer(Stack);
+const AppStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen name="Home" component={HomeScreen} />
+    <Stack.Screen name="Quiz" component={QuizScreen} />
+    <Stack.Screen name="MockExam" component={MockExamScreen} />
+    <Stack.Screen name="Result" component={ResultScreen} />
+    <Stack.Screen name="Advice" component={AdviceScreen} />
+  </Stack.Navigator>
+);
+
+const AppNavigator = () => {
+  const { user } = useContext(AuthContext);
+
+  return (
+    <NavigationContainer linking={linking}>
+      {user ? <AppStack /> : <AuthStack />}
+    </NavigationContainer>
+  );
+};
+
+export default AppNavigator;


### PR DESCRIPTION
## Summary
- update AppNavigator to use `@react-navigation` stack
- wrap navigator in `NavigationContainer` and configure deep links
- remove container wrapper from App.js
- add missing navigation dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685977a01c988320991f2a7175680995