### PR TITLE
Add reusable React Native components

### DIFF
--- a/src/components/AnswerOption.js
+++ b/src/components/AnswerOption.js
@@ -1,11 +1,45 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 
-const AnswerOption = ({ option, onSelect }) => (
-  <TouchableOpacity style={styles.option} onPress={() => onSelect(option)}>
-    <Text>{option}</Text>
-  </TouchableOpacity>
-);
+/**
+ * Display a single answer choice. When results are shown it renders
+ * a check or cross icon depending on correctness and selection.
+ *
+ * Props:
+ * - text: option text
+ * - onPress: callback when pressed
+ * - showResult: if true, show ✅ for correct or ❌ if selected incorrectly
+ * - isCorrect: whether this option is the correct answer
+ * - isSelected: whether the user selected this option
+ * - style: optional container style
+ */
+const AnswerOption = ({
+  text,
+  onPress,
+  showResult = false,
+  isCorrect = false,
+  isSelected = false,
+  style,
+}) => {
+  let icon = '';
+  if (showResult) {
+    if (isCorrect) icon = ' ✅';
+    else if (isSelected) icon = ' ❌';
+  }
+
+  return (
+    <TouchableOpacity
+      style={[styles.option, style]}
+      onPress={onPress}
+      disabled={showResult}
+    >
+      <Text>
+        {text}
+        {icon}
+      </Text>
+    </TouchableOpacity>
+  );
+};
 
 const styles = StyleSheet.create({
   option: {

--- a/src/components/CustomButton.js
+++ b/src/components/CustomButton.js
@@ -1,9 +1,30 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet } from 'react-native';
-
-const CustomButton = ({ title, onPress }) => (
-  <TouchableOpacity style={styles.button} onPress={onPress}>
-    <Text style={styles.text}>{title}</Text>
+/**
+ * Reusable button component used across screens.
+ *
+ * Props:
+ * - title: text to display inside the button
+ * - onPress: callback when pressed
+ * - style: optional style override for the button container
+ * - textStyle: optional style override for the text
+ * - disabled: when true, button cannot be pressed
+ */
+const CustomButton = ({
+  title,
+  onPress,
+  style,
+  textStyle,
+  disabled = false,
+}) => (
+  <TouchableOpacity
+    style={[styles.button, style, disabled && styles.disabledButton]}
+    onPress={onPress}
+    disabled={disabled}
+  >
+    <Text style={[styles.text, textStyle, disabled && styles.disabledText]}>
+      {title}
+    </Text>
   </TouchableOpacity>
 );
 
@@ -15,6 +36,12 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   text: {
+    color: '#fff',
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  disabledText: {
     color: '#fff',
   },
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-const Header = ({ title }) => (
-  <View style={styles.container}>
-    <Text style={styles.title}>{title}</Text>
+/**
+ * Simple top bar header displaying a title.
+ *
+ * Props:
+ * - title: text for the header
+ * - style: optional container style
+ * - textStyle: optional title style
+ */
+const Header = ({ title, style, textStyle }) => (
+  <View style={[styles.container, style]}>
+    <Text style={[styles.title, textStyle]}>{title}</Text>
   </View>
 );
 

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -1,8 +1,15 @@
 import React from 'react';
 import { ActivityIndicator } from 'react-native';
 
-const LoadingSpinner = () => (
-  <ActivityIndicator size="large" color="#2196F3" />
+/**
+ * Simple activity indicator for loading states.
+ *
+ * Props:
+ * - size: indicator size (default 'large')
+ * - color: indicator color (default '#2196F3')
+ */
+const LoadingSpinner = ({ size = 'large', color = '#2196F3' }) => (
+  <ActivityIndicator size={size} color={color} />
 );
 
 export default LoadingSpinner;

--- a/src/screens/AdviceScreen.js
+++ b/src/screens/AdviceScreen.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import CustomButton from '../components/CustomButton';
+import Header from '../components/Header';
 
 const modules = [
   {
@@ -62,15 +64,24 @@ const AdviceScreen = () => {
 
   return (
     <View style={styles.container}>
+      <Header title="Advice" />
       <Text style={styles.title}>{module.title}</Text>
       <Text style={styles.content}>{module.parts[partIndex]}</Text>
       <View style={styles.navigation}>
-        <TouchableOpacity onPress={handlePrev} disabled={isFirst}>
-          <Text style={[styles.button, isFirst && styles.disabled]}>Previous</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={handleNext} disabled={isLast}>
-          <Text style={[styles.button, isLast && styles.disabled]}>Next</Text>
-        </TouchableOpacity>
+        <CustomButton
+          title="Previous"
+          onPress={handlePrev}
+          style={styles.navButton}
+          textStyle={[styles.buttonText, isFirst && styles.disabled]}
+          disabled={isFirst}
+        />
+        <CustomButton
+          title="Next"
+          onPress={handleNext}
+          style={styles.navButton}
+          textStyle={[styles.buttonText, isLast && styles.disabled]}
+          disabled={isLast}
+        />
       </View>
     </View>
   );
@@ -97,7 +108,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
   },
-  button: {
+  navButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    backgroundColor: '#eee',
+    borderRadius: 4,
+    alignItems: 'center',
+  },
+  buttonText: {
     fontSize: 16,
     color: '#2196F3',
   },

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,20 +1,23 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import CustomButton from '../components/CustomButton';
+import Header from '../components/Header';
 
 const HomeScreen = ({ navigation }) => (
   <View style={styles.container}>
-    <TouchableOpacity
-      style={styles.button}
+    <Header title="Home" />
+    <CustomButton
+      title="Review"
       onPress={() => navigation.navigate('Quiz')}
-    >
-      <Text style={styles.buttonText}>Review</Text>
-    </TouchableOpacity>
-    <TouchableOpacity
       style={styles.button}
+      textStyle={styles.buttonText}
+    />
+    <CustomButton
+      title="Advice and Guidance"
       onPress={() => navigation.navigate('Advice')}
-    >
-      <Text style={styles.buttonText}>Advice and Guidance</Text>
-    </TouchableOpacity>
+      style={styles.button}
+      textStyle={styles.buttonText}
+    />
   </View>
 );
 

--- a/src/screens/QuizScreen.js
+++ b/src/screens/QuizScreen.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import CustomButton from '../components/CustomButton';
+import AnswerOption from '../components/AnswerOption';
 
 const questions = [
   {
@@ -41,23 +42,17 @@ const QuizScreen = () => {
   return (
     <View style={styles.container}>
       <Text style={styles.question}>{question.question}</Text>
-      {question.options.map((option, idx) => {
-        let icon = '';
-        if (selected !== null) {
-          if (idx === question.correctIndex) icon = ' ✅';
-          if (idx === selected && idx !== question.correctIndex) icon = ' ❌';
-        }
-        return (
-          <TouchableOpacity
-            key={idx}
-            style={styles.option}
-            onPress={() => handleSelect(idx)}
-            disabled={selected !== null}
-          >
-            <Text>{option}{icon}</Text>
-          </TouchableOpacity>
-        );
-      })}
+      {question.options.map((option, idx) => (
+        <AnswerOption
+          key={idx}
+          text={option}
+          onPress={() => handleSelect(idx)}
+          showResult={selected !== null}
+          isCorrect={idx === question.correctIndex}
+          isSelected={idx === selected}
+          style={styles.option}
+        />
+      ))}
       {selected !== null && (
         <View style={styles.feedbackContainer}>
           <Text style={isCorrect ? styles.correct : styles.incorrect}>


### PR DESCRIPTION
## Summary
- expand `CustomButton` with style and disabled props
- make `Header` and `LoadingSpinner` customizable
- rewrite `AnswerOption` to show check or X after answering
- integrate components in `HomeScreen`, `AdviceScreen`, and `QuizScreen`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685ab2b249208320ad44a343d5d3e7a8