### PR TITLE
Add plan management with Firestore subscription

### DIFF
--- a/src/contexts/PlanContext.js
+++ b/src/contexts/PlanContext.js
@@ -1,12 +1,32 @@
-import React, { createContext, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState
+} from 'react';
+import { AuthContext } from './AuthContext';
+import { subscribeToUserPlan } from '../services/firestoreService';
 
 export const PlanContext = createContext();
 
 export const PlanProvider = ({ children }) => {
-  const [plan, setPlan] = useState(null);
+  const { user } = useContext(AuthContext);
+  const [plan, setPlan] = useState('basic');
+
+  useEffect(() => {
+    let unsubscribe = () => {};
+    if (user) {
+      unsubscribe = subscribeToUserPlan(user.uid, setPlan);
+    } else {
+      setPlan('basic');
+    }
+    return unsubscribe;
+  }, [user]);
+
+  const isPremium = plan === 'premium';
 
   return (
-    <PlanContext.Provider value={{ plan, setPlan }}>
+    <PlanContext.Provider value={{ plan, isPremium }}>
       {children}
     </PlanContext.Provider>
   );

--- a/src/services/firestoreService.js
+++ b/src/services/firestoreService.js
@@ -1,4 +1,20 @@
 // Firestore database helper functions
+import firestore from '@react-native-firebase/firestore';
+
 export const fetchQuestions = async () => {
   // fetch questions from Firestore
+};
+
+export const subscribeToUserPlan = (userId, callback) => {
+  if (!userId) {
+    return () => {};
+  }
+  return firestore()
+    .collection('payments')
+    .doc(userId)
+    .onSnapshot(doc => {
+      const data = doc.data();
+      const plan = data?.plan === 'premium' && data?.active ? 'premium' : 'basic';
+      callback(plan);
+    });
 };


### PR DESCRIPTION
## Summary
- enhance PlanContext to track plan state and expose `isPremium`
- subscribe to payment documents via Firestore to update plan
- add Firestore helper for subscribing to user plan

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685ab4a017e48320b043bc5a51ff8d71