### PR TITLE
Add Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,32 @@
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Users collection - each user can only access their own doc
+    match /users/{userId} {
+      allow get, list, create, update: if request.auth != null && request.auth.uid == userId;
+      allow delete: if false; // users cannot delete their profile from the client
+    }
+
+    // Payments collection - read only by owner, all client writes blocked
+    match /payments/{paymentId} {
+      allow get, list: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow create, update, delete: if false;
+    }
+
+    // Questions collection - read allowed for authenticated users, no client writes
+    match /questions/{questionId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Guidance modules collection - read allowed, no client writes
+    match /guidanceModules/{moduleId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Deny any access to other paths by default
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules to protect users, payments, questions, and guidance modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685abf9403548320aabe57440aee0158