### PR TITLE
Add Firebase Cloud Messaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ src/
     firestoreService.js
     paymentService.js
     adService.js
+    notificationService.js
 ```
 
 App.js at the project root initializes contexts and navigation.

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useEffect } from 'react';
 import auth from '@react-native-firebase/auth';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import { registerDeviceForPushNotifications } from '../services/notificationService';
 
 export const AuthContext = createContext();
 
@@ -12,6 +13,13 @@ export const AuthProvider = ({ children }) => {
     const unsubscribe = auth().onAuthStateChanged(setUser);
     return unsubscribe;
   }, []);
+
+  // Register for push notifications whenever a user is authenticated
+  useEffect(() => {
+    if (user) {
+      registerDeviceForPushNotifications(user.uid);
+    }
+  }, [user]);
 
   const signUp = async (email, password) => {
     try {

--- a/src/services/firestoreService.js
+++ b/src/services/firestoreService.js
@@ -42,6 +42,16 @@ export const updateUserPlanStatus = async (userId, planStatus) => {
   }
 };
 
+// Update or store the FCM token for a user so push notifications can be sent
+export const updateUserFcmToken = async (userId, fcmToken) => {
+  try {
+    await usersCollection.doc(userId).update({ fcmToken });
+  } catch (error) {
+    console.log('Error updating FCM token:', error);
+    throw error;
+  }
+};
+
 // ----- Questions -----
 export const getQuestionsBySubjectAndSubtopic = async (subject, subtopic) => {
   try {

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,0 +1,49 @@
+// Firebase Cloud Messaging helper functions
+import messaging from '@react-native-firebase/messaging';
+import { updateUserFcmToken } from './firestoreService';
+
+/**
+ * Requests notification permission, retrieves the FCM token and stores it in
+ * the user's Firestore document. The device is also subscribed to the
+ * "daily_reminder" topic for broadcast reminders.
+ *
+ * @param {string} userId Firebase authentication UID
+ */
+export const registerDeviceForPushNotifications = async (userId) => {
+  try {
+    const authStatus = await messaging().requestPermission();
+    const granted =
+      authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
+      authStatus === messaging.AuthorizationStatus.PROVISIONAL;
+
+    if (!granted) {
+      console.log('FCM permission not granted');
+      return;
+    }
+
+    const fcmToken = await messaging().getToken();
+    console.log('FCM token obtained:', fcmToken);
+
+    await updateUserFcmToken(userId, fcmToken);
+    console.log('FCM token saved to Firestore');
+
+    await messaging().subscribeToTopic('daily_reminder');
+    console.log('Subscribed to daily_reminder topic');
+  } catch (error) {
+    console.log('Error registering device for push notifications:', error);
+  }
+};
+
+/**
+ * Unsubscribes the device from the daily reminder topic.
+ * Useful when a user disables notifications.
+ */
+export const unsubscribeFromDailyReminder = async () => {
+  try {
+    await messaging().unsubscribeFromTopic('daily_reminder');
+    console.log('Unsubscribed from daily_reminder topic');
+  } catch (error) {
+    console.log('Error unsubscribing from daily_reminder:', error);
+  }
+};
+


### PR DESCRIPTION
## Summary
- add FCM token update utility in `firestoreService`
- add `notificationService` to manage push notifications
- register device for notifications when user signs in
- document new service in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685ac0c9f93483208d55ce38683b988d